### PR TITLE
Federate Firebase Hosting deployments

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 concurrency:
   group: firebase-hosting-live
@@ -29,6 +30,13 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          project_id: noted-reef-387021
+          workload_identity_provider: projects/1012884798546/locations/global/workloadIdentityPools/github-actions-firebase/providers/github-mickeyf-com-main
+          service_account: github-action-635373308@noted-reef-387021.iam.gserviceaccount.com
 
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -51,12 +59,12 @@ jobs:
           VITE_PROD_API_URL: https://mickeyf-org-j7yuum4tiq-uc.a.run.app
 
       - name: Deploy to Firebase Hosting
-        uses: FirebaseExtended/action-hosting-deploy@500ac625ca2dd40cbd15f7659af953801858032a # v0.11.0
-        with:
-          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_NOTED_REEF_387021 }}
-          firebaseToolsVersion: 15.27.0
-          channelId: live
-          projectId: noted-reef-387021
+        run: >-
+          npm exec --yes --package=firebase-tools@15.27.0 --
+          firebase deploy
+          --only hosting
+          --project noted-reef-387021
+          --non-interactive
 
       - name: Notify Slack (result)
         if: always()


### PR DESCRIPTION
## What changed
- authenticates Firebase Hosting deployments with GitHub OIDC and Google Workload Identity Federation
- grants only the workflow's short-lived identity access to the existing limited Firebase deployment account
- removes the workflow's dependency on the long-lived Firebase service-account secret
- runs the pinned Firebase CLI directly with Application Default Credentials

## Why
The existing GitHub secret contains a long-lived Google service-account key. Federation replaces it with credentials that expire within minutes and are restricted to this repository, workflow, and main branch.

## Validation
- workflow YAML parses successfully
- Git diff whitespace validation passes
- live deployment remains the cutover gate; the old key will not be deleted until the merged workflow deploys successfully