### PR TITLE
Separate Cloud Run IAM from backend deploys

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -37,7 +37,6 @@ steps:
       - '${_REGION}'
       - '--platform'
       - 'managed'
-      - '--allow-unauthenticated'
       - '--port'
       - '8080'
       - '--add-cloudsql-instances'


### PR DESCRIPTION
## What changed
- removes the Cloud Run public-IAM mutation flag from backend candidate deployments

## Why
The build identity now uses Cloud Run Developer instead of Cloud Run Admin. Public invoker access is an independently managed service policy and should not be rewritten by every application deployment. The reduced-permission verification build succeeded, but correctly warned that it could not update IAM.

## Validation
- reduced build account completed image build, push, zero-traffic deploy, and Slack notification
- production traffic remained unchanged
- cloudbuild.yaml parses successfully
- diff whitespace validation passes