### PR TITLE
chore: limit routine Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,8 @@
 version: 2
 
+# Keep routine version PRs to patch/minor releases. Dependabot security updates
+# are unaffected by allow.update-types and may still cross a major boundary.
+
 updates:
   - package-ecosystem: npm
     directory: /
@@ -10,6 +13,11 @@ updates:
       timezone: America/Sao_Paulo
     open-pull-requests-limit: 5
     versioning-strategy: increase-if-necessary
+    allow:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-minor
+          - version-update:semver-patch
     groups:
       root-npm:
         patterns:
@@ -27,6 +35,11 @@ updates:
       timezone: America/Sao_Paulo
     open-pull-requests-limit: 5
     versioning-strategy: increase-if-necessary
+    allow:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-minor
+          - version-update:semver-patch
     groups:
       frontend-npm:
         patterns:
@@ -44,6 +57,11 @@ updates:
       timezone: America/Sao_Paulo
     open-pull-requests-limit: 5
     versioning-strategy: increase-if-necessary
+    allow:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-minor
+          - version-update:semver-patch
     groups:
       backend-npm:
         patterns:
@@ -60,6 +78,11 @@ updates:
       time: "09:30"
       timezone: America/Sao_Paulo
     open-pull-requests-limit: 5
+    allow:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-minor
+          - version-update:semver-patch
     groups:
       github-actions:
         patterns:
@@ -73,3 +96,8 @@ updates:
       time: "09:40"
       timezone: America/Sao_Paulo
     open-pull-requests-limit: 5
+    allow:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-minor
+          - version-update:semver-patch


### PR DESCRIPTION
## Summary
- limit routine Dependabot version PRs to minor and patch releases for npm, GitHub Actions, and Docker
- keep grouped minor/patch updates in the existing weekly schedule
- preserve Dependabot security updates, including fixes that cross a major-version boundary, because `allow.update-types` applies only to version updates

## Verification
- parsed `.github/dependabot.yml` as YAML and asserted all five ecosystems use the intended policy
- `git diff --check`
- no dependency or application files changed

Official behavior: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#update-types-allow