### PR TITLE
ci: update artifact actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -62,7 +62,7 @@ jobs:
         run: npm run docs
 
       - name: Upload generated docs
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: generated-docs
           path: docs
@@ -84,7 +84,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download generated docs
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: generated-docs
           path: ${{ runner.temp }}/generated-docs


### PR DESCRIPTION
## Summary
- update the SHA-pinned documentation artifact upload action from v4.6.2 to v7.0.1
- update the SHA-pinned documentation artifact download action from v4.3.0 to v8.0.1
- remove the deprecated Node 20 action-runtime warning observed in the live docs workflow

## Verification
- workflow YAML parses successfully
- `git diff --check`
- both actions remain pinned to immutable commit SHAs
- after merge, the real main-branch docs workflow will be required to pass before this is considered complete