### PR TITLE
docs: explain Pages publication guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The generated TypeDoc site is published at
 [good-loops.github.io/mickeyf.com](https://good-loops.github.io/mickeyf.com/).
 It covers the frontend and backend modules and is updated from `main` by the
 documentation workflow.
+Pull requests build the site for validation, while only `main` can publish it.
 
 ## Technology
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ The generated TypeDoc site is published at
 [good-loops.github.io/mickeyf.com](https://good-loops.github.io/mickeyf.com/).
 It covers the frontend and backend modules and is updated from `main` by the
 documentation workflow.
-Pull requests build the site for validation, while only `main` can publish it.
+Pull requests that change documentation inputs build the site for validation,
+while only `main` can publish it.
 
 ## Technology
 


### PR DESCRIPTION
## What

Document that pull requests validate TypeDoc while only `main` can publish the GitHub Pages site.

## Why

This small documentation change is also the end-to-end smoke test for the newly active default-branch ruleset.

## Expected protection proof

- merge must go through a pull request
- the branch must be current with `main`
- `Web audit, test, and build` must pass
- `Unity source integrity` must pass
- no admin or app bypass is configured

No application, cloud, or deployment configuration changes are included.