### PR TITLE
fix: preserve Cloud SDK path in deployment

### DIFF
--- a/cloudbuild.deploy.yaml
+++ b/cloudbuild.deploy.yaml
@@ -18,7 +18,7 @@ steps:
       - 'SOURCE_BUILD_ID=${_SOURCE_BUILD_ID}'
       - 'SOURCE_STATUS=${_SOURCE_STATUS}'
     args:
-      - '-lc'
+      - '-c'
       - |
         set -euo pipefail
         umask 077
@@ -182,7 +182,7 @@ steps:
     name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:alpine@sha256:de1a989b158694a614852e7b53673097da3bdb394b8186d6102386b7a10d73c7'
     entrypoint: 'bash'
     args:
-      - '-lc'
+      - '-c'
       - |
         set -euo pipefail
         umask 077
@@ -310,7 +310,7 @@ steps:
     name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:alpine@sha256:de1a989b158694a614852e7b53673097da3bdb394b8186d6102386b7a10d73c7'
     entrypoint: 'bash'
     args:
-      - '-lc'
+      - '-c'
       - |
         set -euo pipefail
         umask 077
@@ -508,7 +508,7 @@ steps:
     secretEnv:
       - 'SLACK_WEBHOOK_URL'
     args:
-      - '-lc'
+      - '-c'
       - |
         set -euo pipefail
         readonly NOTIFICATION_JSON='/workspace/slack-notification.json'


### PR DESCRIPTION
## What changed

Changed each Stage B shell invocation from login-shell mode to normal command mode.

## Why

The gated Stage B proof failed in its first validation step because login-shell startup reset the pinned image's `PATH`, hiding `/google-cloud-sdk/bin/gcloud`. The build stopped before any deployment, and production remained unchanged.

## Validation

- Reproduced the missing CLI under login-shell mode in the exact pinned image.
- Confirmed normal command mode resolves `gcloud`, Python, Bash, and `seq`.
- All four scripts pass Bash syntax checks in the pinned image.
- Every Google Cloud subcommand and deploy flag used by Stage B is available.
- Argument sizes remain below the Cloud Build limit.
- Independent review found no lost initialization or credential behavior.