### PR TITLE
fix: shorten backend candidate tag

### DIFF
--- a/cloudbuild.deploy.yaml
+++ b/cloudbuild.deploy.yaml
@@ -163,7 +163,7 @@ steps:
         compact_id = build_id.replace("-", "")
         state = {
             "build_id": build_id,
-            "candidate_tag": f"phase10-candidate-{compact_id}",
+            "candidate_tag": f"c-{compact_id}",
             "commit": commit,
             "digest": digest,
             "revision_name": f"mickeyf-org-build-{compact_id}",
@@ -221,7 +221,7 @@ steps:
         if re.fullmatch(r"sha256:[0-9a-f]{64}", state["digest"]) is None:
             raise SystemExit("state digest is malformed")
         expected = {
-            "candidate_tag": f"phase10-candidate-{compact}",
+            "candidate_tag": f"c-{compact}",
             "revision_name": f"mickeyf-org-build-{compact}",
             "revision_suffix": f"build-{compact}",
             "target_image": f"{image}@{state['digest']}",
@@ -347,7 +347,7 @@ steps:
         compact = build_id.replace("-", "")
         image = "us-central1-docker.pkg.dev/noted-reef-387021/cloud-run-source-deploy/cloud-run-source-deploy"
         expected = {
-            "candidate_tag": f"phase10-candidate-{compact}",
+            "candidate_tag": f"c-{compact}",
             "revision_name": f"mickeyf-org-build-{compact}",
             "revision_suffix": f"build-{compact}",
             "target_image": f"{image}@{state['digest']}",


### PR DESCRIPTION
## What changed

Shortened the deterministic Stage B candidate tag prefix while retaining the complete compact Cloud Build identifier.

## Why

The gated Stage B proof passed authoritative validation but Cloud Run rejected the zero-traffic deploy because the previous tag plus service name exceeded the platform's 46-character limit. No revision was created and production remained unchanged.

## Validation

- New tag is 34 characters; service plus tag is 45.
- The complete generated hostname segment remains below Cloud Run's limit.
- Full build identifier preserves one-to-one uniqueness and deterministic replay.
- Both downstream trust boundaries independently recompute the tag.
- Post-deployment verification still requires the tag to resolve uniquely to the expected revision.
- All scripts and embedded Python blocks pass syntax checks; all arguments remain below the Cloud Build limit.
- Independent review found no blocker.