### PR TITLE
fix: normalize backend candidate CPU

### DIFF
--- a/cloudbuild.deploy.yaml
+++ b/cloudbuild.deploy.yaml
@@ -423,7 +423,12 @@ steps:
             reject("runtime image is not the verified digest")
         if container.get("ports") != [{"containerPort": 8080, "name": "http1"}]:
             reject("HTTP port configuration does not match")
-        if (container.get("resources") or {}).get("limits") != {"cpu": "1000m", "memory": "512Mi"}:
+        limits = (container.get("resources") or {}).get("limits") or {}
+        if (
+            set(limits) != {"cpu", "memory"}
+            or limits.get("cpu") not in ("1", "1000m")
+            or limits.get("memory") != "512Mi"
+        ):
             reject("CPU or memory limits do not match")
         probe = container.get("startupProbe") or {}
         if (int(probe.get("failureThreshold") or 0), int(probe.get("periodSeconds") or 0),


### PR DESCRIPTION
## What changed

Updated the Stage B post-deployment verifier to accept the two exact Cloud Run representations of one CPU: `1` and `1000m`.

The verifier still requires exactly the `cpu` and `memory` keys, fixes memory at `512Mi`, and rejects all fractional, multi-CPU, missing, or extra resource values.

## Why

The gated proof successfully created a healthy zero-traffic candidate, but Cloud Run serialized the requested one CPU as `1`; the older production revision stores the equivalent value as `1000m`. The strict string comparison rejected this semantic equivalence. Production traffic remained unchanged.

## Validation

- Full read-only replay of every other runtime and traffic assertion passed against the candidate.
- Candidate is ready, zero traffic, exact verified digest, dedicated runtime identity, exact DB/secret settings, and expected runtime limits.
- Production remains on the prior validated revision at 100%.
- All shell scripts and embedded Python blocks pass syntax checks.
- Every build argument remains below the platform limit.
- Independent review found no blocker or other likely normalization mismatch.