### PR TITLE
ci: rotate session secret to version 2

### DIFF
--- a/cloudbuild.deploy.yaml
+++ b/cloudbuild.deploy.yaml
@@ -654,7 +654,7 @@ steps:
             --startup-probe='timeoutSeconds=240,periodSeconds=240,failureThreshold=1,tcpSocket.port=8080' \
             --liveness-probe='' --set-cloudsql-instances="$$CLOUD_SQL" \
             --set-env-vars="NODE_ENV=production,CLOUD_SQL_CONNECTION_NAME=$$CLOUD_SQL,DB_USER=cms_mickeyf,DB_NAME=cms" \
-            --set-secrets='DB_PASS=DB_PASS:1,SESSION_SECRET=SESSION_SECRET:1' \
+            --set-secrets='DB_PASS=DB_PASS:1,SESSION_SECRET=SESSION_SECRET:2' \
             --update-labels="source-build-id=$$SOURCE_BUILD_ID,source-commit=$$COMMIT_SHA" \
             --no-traffic --tag="$$CANDIDATE_TAG" --quiet; then
             deployed_here=true
@@ -854,10 +854,14 @@ steps:
         for name, value in plain.items():
             if env.get(name) != {"name": name, "value": value}:
                 reject(f"environment value {name} does not match")
-        for name in ("DB_PASS", "SESSION_SECRET"):
+        secret_versions = {
+            "DB_PASS": "1",
+            "SESSION_SECRET": "2",
+        }
+        for name, version in secret_versions.items():
             item = env.get(name) or {}
             ref = (item.get("valueFrom") or {}).get("secretKeyRef") or {}
-            if item.get("name") != name or ref != {"key": "1", "name": name}:
+            if item.get("name") != name or ref != {"key": version, "name": name}:
                 reject(f"numeric secret reference {name} does not match")
 
         revision_percent = sum(int(item.get("percent") or 0) for item in after.get("status", {}).get("traffic", []) if item.get("revisionName") == revision_name)


### PR DESCRIPTION
## What changed

- pin `SESSION_SECRET` to Secret Manager version 2 in the Stage B Cloud Run deployment
- keep `DB_PASS` pinned to version 1
- verify the two numeric secret versions independently after deployment

## Why

A historical `cloudbuild.yaml` contained a plaintext session-secret value introduced on the same date as the current version. The value is not present in the current tree, but reuse is plausible, so version 1 is being treated as compromised and rotated without displaying or comparing either value.

## Impact

This configuration-only change does not move production traffic by itself. After merge, the source-less Stage B trigger will be updated from the exact merged file and Stage A will be run explicitly. Cutover will be atomic rather than a mixed-version canary, and existing sessions will be signed out once.

## Validation

- YAML parse and nine-step policy shape
- all Bash entry scripts syntax-checked
- all embedded Python programs compiled
- positive and negative secret-version verifier fixtures
- every Cloud Build argument remains below 10,000 bytes
- `git diff --check`

## Rollout safeguards

A scan-clean previous-code rollback clone already exists at zero traffic with `SESSION_SECRET:2`. The new current-code candidate will also be validated at zero traffic, including a user-entered login/session/logout test, before the atomic switch.