### PR TITLE
Audit Firebase deployment tooling dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -70,6 +70,28 @@ updates:
           - minor
           - patch
 
+  - package-ecosystem: npm
+    directory: /.github/firebase-deploy
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:25"
+      timezone: America/Sao_Paulo
+    open-pull-requests-limit: 5
+    versioning-strategy: increase-if-necessary
+    allow:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-minor
+          - version-update:semver-patch
+    groups:
+      firebase-deploy-npm:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -34,6 +34,7 @@ jobs:
             package-lock.json
             frontend/package-lock.json
             backend/package-lock.json
+            .github/firebase-deploy/package-lock.json
 
       - name: Use project npm version
         run: npm install --global npm@11.6.2 --no-audit --no-fund
@@ -43,12 +44,14 @@ jobs:
           npm ci --no-audit
           npm --prefix frontend ci --no-audit
           npm --prefix backend ci --no-audit
+          npm --prefix .github/firebase-deploy ci --ignore-scripts --no-audit --no-fund
 
       - name: Audit npm dependencies
         run: |
           npm audit --audit-level=low
           npm --prefix frontend audit --audit-level=low
           npm --prefix backend audit --audit-level=low
+          npm --prefix .github/firebase-deploy audit --audit-level=high --omit=dev
 
       - name: Type-check and build frontend
         run: |

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ local infrastructure.
 
 ## Native Windows development
 
-Native Windows 11 is the supported development environment. The maintained
-checkout is expected at:
+Native Windows 11 is the supported development environment. The checkout can
+live in any local folder; the commands below assume this repository root:
 
 ```text
-C:\Users\User\Desktop\Pastas\Code\mickeyf.com
+<path-to-your-checkout>\mickeyf.com
 ```
 
 ### Prerequisites
@@ -103,7 +103,7 @@ copied into Git.
 3. Open the native Windows folder in VS Code:
 
    ```powershell
-   code "C:\Users\User\Desktop\Pastas\Code\mickeyf.com"
+   code .
    ```
 
 4. Run `Terminal: Run Task`, then select `Development: app`.

--- a/unity/three-bosses/README.md
+++ b/unity/three-bosses/README.md
@@ -5,10 +5,10 @@ monorepo.
 
 ## Open the project
 
-In Unity Hub, add and open this exact directory:
+In Unity Hub, add and open this directory from the repository root:
 
 ```text
-C:\Users\User\Desktop\Pastas\Code\mickeyf.com\unity\three-bosses
+unity\three-bosses
 ```
 
 Use Unity 6.3 LTS editor version 6000.3.8f1. Do not upgrade the editor as part


### PR DESCRIPTION
## What changed

- add Dependabot coverage for the isolated Firebase deployment tool lockfile
- install with lifecycle scripts disabled and audit high/critical findings inside the existing required web CI check
- replace machine-specific Windows checkout paths with portable documentation

## Why

The Firebase deploy job is now credential-isolated, but its private tool lockfile was outside Dependabot and pull-request audit coverage. This closes that monitoring gap without exposing OIDC credentials or repository secrets to dependency code.

## Validation

- locked Firebase CLI remains 15.27.0
- `npm ci --ignore-scripts` succeeds
- `npm audit --audit-level=high --omit=dev` reports zero high/critical findings
- five known moderate upstream Firebase CLI transitive advisories remain accepted pending a compatible upstream release
- workflow/dependabot YAML, permissions, action pins, diff whitespace, and portable-path checks pass
