### PR TITLE
Restore VS Code startup terminals

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "ethansk.restore-terminals"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,38 @@
 {
+    "restoreTerminals.runOnStartup": true,
+    "restoreTerminals.keepExistingTerminalsOpen": false,
+    "restoreTerminals.terminals": [
+        {
+            "cwd": "${workspaceFolder}/frontend",
+            "splitTerminals": [
+                {
+                    "name": "front",
+                    "commands": [
+                        "npm run dev"
+                    ]
+                }
+            ]
+        },
+        {
+            "cwd": "${workspaceFolder}",
+            "splitTerminals": [
+                {
+                    "name": "docs",
+                    "commands": [
+                        "npm run docs:dev"
+                    ]
+                }
+            ]
+        },
+        {
+            "cwd": "${workspaceFolder}",
+            "splitTerminals": [
+                {
+                    "name": "general"
+                }
+            ]
+        }
+    ],
     "editor.inlineSuggest.enabled": true,
     "editor.suggest.preview": true,
     "editor.tabCompletion": "onlySnippets"

--- a/README.md
+++ b/README.md
@@ -106,11 +106,20 @@ copied into Git.
    code .
    ```
 
-4. Run `Terminal: Run Task`, then select `Development: app`.
+4. Install the recommended **Restore Terminals** extension if VS Code prompts
+   for it, then reload the workspace. VS Code automatically opens:
 
-The compound task starts the frontend Vite server, backend webpack watcher,
-and backend nodemon server in separate terminals. It does not start the
-documentation server or infrastructure implicitly.
+   - `front`, running the frontend Vite server;
+   - `docs`, running the TypeDoc development server; and
+   - `general`, an idle shell at the repository root.
+
+5. For backend development, run `Terminal: Run Task`, then select
+   `Backend: dev + watch`.
+
+If you do not use the recommended extension, the `Development: app` compound
+task starts the frontend Vite server, backend webpack watcher, and backend
+nodemon server in separate terminals. Infrastructure is never started
+implicitly.
 
 The equivalent manual commands, each in its own terminal, are:
 


### PR DESCRIPTION
## What changed

- restore the `front`, `docs`, and `general` terminal groups when the repository opens in VS Code
- use workspace-relative working directories and native npm commands instead of restoring the retired Linux shell profile
- explicitly close prior restored terminals before recreating the three groups, avoiding duplicates
- recommend the Restore Terminals extension and document automatic versus manual startup

## Root cause

The August 17 native-Windows migration removed the whole `restoreTerminals.terminals` block while deleting the Linux-only `rbash` profile. The replacement VS Code tasks were intentionally manual, so the previous startup behavior disappeared.

## Validation

- VS Code settings and extension recommendations parse as JSON
- installed Restore Terminals 1.1.11 schema supports `cwd` and `${workspaceFolder}`
- frontend and documentation npm scripts exist
- exact startup names, working directories, commands, and idle general shell are asserted
- no Linux-specific profile was restored
- diff whitespace checks pass
