### PR TITLE
Improve VS Code and Unity developer tooling

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,54 @@
+# Git hooks
+
+This directory holds versioned Git hooks that are not part of Git's default
+`.git/hooks` search path. Nothing here runs until it is activated.
+
+## Activation
+
+Run once after cloning the repository:
+
+```powershell
+npm run hooks:install
+```
+
+This sets `core.hooksPath` to `.githooks` for this local checkout only. It
+does not modify any other clone or CI.
+
+Verify the setting at any time with:
+
+```powershell
+git config --get core.hooksPath
+```
+
+It should print `.githooks`.
+
+## What `pre-commit` does
+
+The hook runs `node scripts/normalize-unity-yaml-whitespace.mjs --staged`,
+which normalizes Unity-generated trailing spaces and tabs in staged text
+assets under `unity/three-bosses` (`.unity`, `.prefab`, `.asset`, `.meta`,
+`.mat`, `.anim`, `.controller`).
+
+- If normalization changes any file, the hook **stops the current commit on
+  purpose**. Inspect the diff of the newly normalized, already re-staged
+  files, then run the commit again. The second attempt proceeds normally
+  once no further normalization is required.
+- If a staged Unity file also has unstaged changes (it is only **partially
+  staged**), the hook refuses to touch it and stops the commit. Stage or
+  discard the remaining working-tree changes for the listed paths, then
+  retry.
+- Unity may stay open while you commit. Save any open scenes **before**
+  starting the commit, and avoid saving a scene while the hook is running, so
+  Unity does not rewrite a file out from under the hook mid-commit.
+
+## Testing the normalizer
+
+```powershell
+npm run test:unity-yaml-normalizer
+```
+
+## Bypassing the hook
+
+`git commit --no-verify` skips this hook entirely, including the partial-
+staging and whitespace safeguards it enforces. Treat it as an emergency
+escape hatch, not routine usage.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+set -e
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+node scripts/normalize-unity-yaml-whitespace.mjs --staged

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
     "recommendations": [
-        "ReinaldoJavierMenendezAlonso.restore-terminals-color-icon"
+        "ReinaldoJavierMenendezAlonso.restore-terminals-color-icon",
+        "visualstudiotoolsforunity.vstuc"
     ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,5 @@
 {
     "recommendations": [
-        "ethansk.restore-terminals"
+        "ReinaldoJavierMenendezAlonso.restore-terminals-color-icon"
     ]
 }

--- a/.vscode/restore-terminals.json
+++ b/.vscode/restore-terminals.json
@@ -1,0 +1,49 @@
+{
+  "artificialDelayMilliseconds": 1000,
+  "keepExistingTerminalsOpen": false,
+  "runOnStartup": true,
+  "terminals": [
+    {
+      "cwd": "${workspaceFolder}/frontend",
+      "splitTerminals": [
+        {
+          "name": "front",
+          "icon": "browser",
+          "color": "terminal.ansiCyan",
+          "commands": [
+            "cd \"$(git rev-parse --show-toplevel)/frontend\" && npm run dev"
+          ],
+          "shouldRunCommands": true
+        }
+      ]
+    },
+    {
+      "cwd": "${workspaceFolder}",
+      "splitTerminals": [
+        {
+          "name": "docs",
+          "icon": "book",
+          "color": "terminal.ansiGreen",
+          "commands": [
+            "npm run docs:dev"
+          ],
+          "shouldRunCommands": true
+        }
+      ]
+    },
+    {
+      "cwd": "${workspaceFolder}",
+      "splitTerminals": [
+        {
+          "name": "general",
+          "icon": "terminal-bash",
+          "color": "terminal.ansiBlue",
+          "commands": [
+            "copilot"
+          ],
+          "shouldRunCommands": true
+        }
+      ]
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,12 @@
     "terminal.integrated.defaultProfile.windows": "Git Bash",
     "editor.inlineSuggest.enabled": true,
     "editor.suggest.preview": true,
-    "editor.tabCompletion": "onlySnippets"
+    "editor.tabCompletion": "onlySnippets",
+    "dotnet.defaultSolution": "unity/three-bosses/three-bosses.slnx",
+    "files.associations": {
+        "*.asset": "yaml",
+        "*.meta": "yaml",
+        "*.prefab": "yaml",
+        "*.unity": "yaml"
+    }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,38 +1,18 @@
 {
-    "restoreTerminals.runOnStartup": true,
-    "restoreTerminals.keepExistingTerminalsOpen": false,
-    "restoreTerminals.terminals": [
-        {
-            "cwd": "${workspaceFolder}/frontend",
-            "splitTerminals": [
-                {
-                    "name": "front",
-                    "commands": [
-                        "npm run dev"
-                    ]
-                }
-            ]
-        },
-        {
-            "cwd": "${workspaceFolder}",
-            "splitTerminals": [
-                {
-                    "name": "docs",
-                    "commands": [
-                        "npm run docs:dev"
-                    ]
-                }
-            ]
-        },
-        {
-            "cwd": "${workspaceFolder}",
-            "splitTerminals": [
-                {
-                    "name": "general"
-                }
-            ]
+    "terminal.integrated.profiles.windows": {
+        "Git Bash": {
+            "path": "C:\\Program Files\\Git\\bin\\bash.exe",
+            "args": [
+                "--login",
+                "-i"
+            ],
+            "env": {
+                "CHERE_INVOKING": "1"
+            },
+            "icon": "terminal-bash"
         }
-    ],
+    },
+    "terminal.integrated.defaultProfile.windows": "Git Bash",
     "editor.inlineSuggest.enabled": true,
     "editor.suggest.preview": true,
     "editor.tabCompletion": "onlySnippets"

--- a/README.md
+++ b/README.md
@@ -169,6 +169,30 @@ npm --prefix backend run test
 npm --prefix backend run prod
 ```
 
+## Developer tooling
+
+Run once after cloning, from the repository root:
+
+```powershell
+npm run hooks:install
+```
+
+This activates the tracked `.githooks/pre-commit` hook, which normalizes
+Unity-generated trailing spaces and tabs in staged Unity text assets under
+`unity/three-bosses` before a commit is created. If normalization changes
+anything, the hook intentionally stops that commit so you can review the
+result and commit again; a Unity file that is only partially staged is
+rejected instead of being modified. Unity can remain open as long as any
+edited scene is saved before you start the commit and is not saved again
+while the hook runs. See [`.githooks/README.md`](.githooks/README.md) for
+details, including the `--no-verify` bypass.
+
+Test the normalizer itself with:
+
+```powershell
+npm run test:unity-yaml-normalizer
+```
+
 ## Unity project location
 
 The Three Bosses Unity project is stored at:

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
 		"docs": "npm run docs:clean && npm run docs:json && npm run docs:build",
 		"docs:serve": "http-server docs -p 8081",
 		"docs:watch": "chokidar \"typedoc.merge.json\" \"docs-src/index.md\" \"docs-src/typedoc.css\" \"docs-src/assets/**/*\" \"frontend/ts/**/*.ts\" \"frontend/ts/**/*.tsx\" \"backend/ts/**/*.ts\" -c \"npm run docs\"",
-		"docs:dev": "npm run docs && concurrently \"npm:docs:watch\" \"npm:docs:serve\""
+		"docs:dev": "concurrently \"npm:docs:watch\" \"npm:docs:serve\"",
+		"docs:dev:fresh": "npm run docs && npm run docs:dev"
 	},
 	"devDependencies": {
 		"chokidar-cli": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
 		"docs:serve": "http-server docs -p 8081",
 		"docs:watch": "chokidar \"typedoc.merge.json\" \"docs-src/index.md\" \"docs-src/typedoc.css\" \"docs-src/assets/**/*\" \"frontend/ts/**/*.ts\" \"frontend/ts/**/*.tsx\" \"backend/ts/**/*.ts\" -c \"npm run docs\"",
 		"docs:dev": "concurrently \"npm:docs:watch\" \"npm:docs:serve\"",
-		"docs:dev:fresh": "npm run docs && npm run docs:dev"
+		"docs:dev:fresh": "npm run docs && npm run docs:dev",
+		"hooks:install": "git config core.hooksPath .githooks",
+		"test:unity-yaml-normalizer": "node --test scripts/normalize-unity-yaml-whitespace.test.mjs",
+		"unity:yaml:normalize-staged": "node scripts/normalize-unity-yaml-whitespace.mjs --staged"
 	},
 	"devDependencies": {
 		"chokidar-cli": "^3.0.0",

--- a/scripts/normalize-unity-yaml-whitespace.mjs
+++ b/scripts/normalize-unity-yaml-whitespace.mjs
@@ -1,0 +1,248 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { basename, dirname, extname, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const UNITY_PROJECT_PATHSPEC = 'unity/three-bosses';
+
+const ELIGIBLE_EXTENSIONS = new Set([
+    '.unity',
+    '.prefab',
+    '.asset',
+    '.meta',
+    '.mat',
+    '.anim',
+    '.controller',
+]);
+
+/**
+ * Splits a NUL-delimited Git command output into a list of paths.
+ * @param {string} output
+ * @returns {string[]}
+ */
+export function parseNulDelimitedList(output) {
+    return output.split('\0').filter((entry) => entry.length > 0);
+}
+
+/**
+ * Returns whether a path's extension makes it an eligible Unity text asset.
+ * Comparison is case-insensitive.
+ * @param {string} filePath
+ * @returns {boolean}
+ */
+export function isEligibleAssetPath(filePath) {
+    return ELIGIBLE_EXTENSIONS.has(extname(filePath).toLowerCase());
+}
+
+/**
+ * Returns whether a buffer contains a NUL byte, used as a cheap binary check.
+ * @param {Buffer} buffer
+ * @returns {boolean}
+ */
+export function containsNulByte(buffer) {
+    return buffer.includes(0);
+}
+
+/**
+ * Removes spaces and tabs that appear immediately before an LF, a CRLF, or
+ * the end of the text. All other bytes, including existing line-ending
+ * style, are preserved untouched.
+ * @param {string} text
+ * @returns {string}
+ */
+export function normalizeTrailingWhitespace(text) {
+    return text
+        .replace(/[ \t]+(\r\n|\n)/g, '$1')
+        .replace(/[ \t]+$/, '');
+}
+
+/**
+ * Decodes a buffer to a string that preserves every byte 1:1, so that
+ * re-encoding with the same codec reproduces the original bytes exactly.
+ * @param {Buffer} buffer
+ * @returns {string}
+ */
+function bufferToBytePreservingString(buffer) {
+    return buffer.toString('latin1');
+}
+
+/**
+ * Encodes a byte-preserving string (see {@link bufferToBytePreservingString})
+ * back into a buffer.
+ * @param {string} text
+ * @returns {Buffer}
+ */
+function bytePreservingStringToBuffer(text) {
+    return Buffer.from(text, 'latin1');
+}
+
+function runGit(repoRoot, args) {
+    return execFileSync('git', args, { cwd: repoRoot, encoding: 'utf8' });
+}
+
+function getRepositoryRoot() {
+    return execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' }).trim();
+}
+
+function getStagedEligiblePaths(repoRoot) {
+    const output = runGit(repoRoot, [
+        'diff',
+        '--cached',
+        '--name-only',
+        '-z',
+        '--diff-filter=ACMR',
+        '--',
+        UNITY_PROJECT_PATHSPEC,
+    ]);
+
+    return parseNulDelimitedList(output).filter(isEligibleAssetPath);
+}
+
+function getUnstagedChangedPaths(repoRoot) {
+    const output = runGit(repoRoot, [
+        'diff',
+        '--name-only',
+        '-z',
+        '--',
+        UNITY_PROJECT_PATHSPEC,
+    ]);
+
+    return new Set(parseNulDelimitedList(output));
+}
+
+function writeFileAtomic(targetPath, buffer) {
+    const dir = dirname(targetPath);
+    const tempPath = join(
+        dir,
+        `.${basename(targetPath)}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+
+    writeFileSync(tempPath, buffer);
+    renameSync(tempPath, targetPath);
+}
+
+function runCachedWhitespaceCheck(repoRoot) {
+    const result = spawnSync('git', ['diff', '--cached', '--check'], {
+        cwd: repoRoot,
+        stdio: 'inherit',
+    });
+
+    return result.status === 0;
+}
+
+function main() {
+    if (!process.argv.includes('--staged')) {
+        console.error('Usage: node scripts/normalize-unity-yaml-whitespace.mjs --staged');
+        process.exitCode = 1;
+        return;
+    }
+
+    const repoRoot = getRepositoryRoot();
+    const stagedEligiblePaths = getStagedEligiblePaths(repoRoot);
+
+    if (stagedEligiblePaths.length === 0) {
+        if (!runCachedWhitespaceCheck(repoRoot)) {
+            process.exitCode = 1;
+            return;
+        }
+
+        process.exitCode = 0;
+        return;
+    }
+
+    const unstagedChangedPaths = getUnstagedChangedPaths(repoRoot);
+    const partiallyStagedPaths = stagedEligiblePaths.filter((path) => unstagedChangedPaths.has(path));
+
+    if (partiallyStagedPaths.length > 0) {
+        console.error('Refusing to normalize partially staged Unity files. Stage or discard the');
+        console.error('remaining working-tree changes for these paths, then retry the commit:');
+        for (const path of partiallyStagedPaths) {
+            console.error(`  ${path}`);
+        }
+
+        process.exitCode = 1;
+        return;
+    }
+
+    const changedPaths = [];
+
+    for (const path of stagedEligiblePaths) {
+        const absolutePath = join(repoRoot, path);
+        let original;
+
+        try {
+            original = readFileSync(absolutePath);
+        } catch (error) {
+            if (error.code === 'ENOENT') {
+                continue;
+            }
+
+            throw error;
+        }
+
+        if (containsNulByte(original)) {
+            continue;
+        }
+
+        const originalText = bufferToBytePreservingString(original);
+        const normalizedText = normalizeTrailingWhitespace(originalText);
+
+        if (normalizedText === originalText) {
+            continue;
+        }
+
+        writeFileAtomic(absolutePath, bytePreservingStringToBuffer(normalizedText));
+        changedPaths.push(path);
+    }
+
+    if (changedPaths.length === 0) {
+        if (!runCachedWhitespaceCheck(repoRoot)) {
+            process.exitCode = 1;
+            return;
+        }
+
+        process.exitCode = 0;
+        return;
+    }
+
+    runGit(repoRoot, ['add', '--', ...changedPaths]);
+
+    const restagedUnstagedPaths = new Set(
+        parseNulDelimitedList(
+            runGit(repoRoot, ['diff', '--name-only', '-z', '--', ...changedPaths]),
+        ),
+    );
+
+    if (restagedUnstagedPaths.size > 0) {
+        console.error('The following files changed on disk again after normalization, likely');
+        console.error('because Unity or another program rewrote them while the hook was running:');
+        for (const path of restagedUnstagedPaths) {
+            console.error(`  ${path}`);
+        }
+
+        process.exitCode = 1;
+        return;
+    }
+
+    if (!runCachedWhitespaceCheck(repoRoot)) {
+        process.exitCode = 1;
+        return;
+    }
+
+    console.log('Normalized trailing whitespace in Unity-generated files:');
+    for (const path of changedPaths) {
+        console.log(`  ${path}`);
+    }
+
+    console.log('');
+    console.log('The commit was intentionally stopped so the normalized changes can be');
+    console.log('inspected. Review the diff, re-stage if needed, and run the commit again.');
+
+    process.exitCode = 1;
+}
+
+const isMainModule = process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url;
+
+if (isMainModule) {
+    main();
+}

--- a/scripts/normalize-unity-yaml-whitespace.test.mjs
+++ b/scripts/normalize-unity-yaml-whitespace.test.mjs
@@ -1,0 +1,200 @@
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { after, before, describe, test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+    containsNulByte,
+    isEligibleAssetPath,
+    normalizeTrailingWhitespace,
+    parseNulDelimitedList,
+} from './normalize-unity-yaml-whitespace.mjs';
+
+const scriptPath = fileURLToPath(new URL('./normalize-unity-yaml-whitespace.mjs', import.meta.url));
+
+describe('normalizeTrailingWhitespace', () => {
+    test('preserves LF line endings while removing trailing whitespace', () => {
+        const input = 'foo \nbar\n';
+        assert.equal(normalizeTrailingWhitespace(input), 'foo\nbar\n');
+    });
+
+    test('preserves CRLF line endings while removing trailing whitespace', () => {
+        const input = 'foo \r\nbar\t\r\n';
+        assert.equal(normalizeTrailingWhitespace(input), 'foo\r\nbar\r\n');
+    });
+
+    test('removes trailing whitespace at end of file with no trailing newline', () => {
+        const input = 'foo\t  ';
+        assert.equal(normalizeTrailingWhitespace(input), 'foo');
+    });
+
+    test('preserves internal, non-trailing whitespace', () => {
+        const input = 'a  b \tc\n';
+        assert.equal(normalizeTrailingWhitespace(input), 'a  b \tc\n');
+    });
+
+    test('leaves lines with no trailing whitespace unchanged', () => {
+        const input = 'clean line\nanother clean line\n';
+        assert.equal(normalizeTrailingWhitespace(input), input);
+    });
+
+    test('handles blank lines with trailing whitespace', () => {
+        const input = 'a\n   \nb\n';
+        assert.equal(normalizeTrailingWhitespace(input), 'a\n\nb\n');
+    });
+});
+
+describe('isEligibleAssetPath', () => {
+    for (const extension of ['.unity', '.prefab', '.asset', '.meta', '.mat', '.anim', '.controller']) {
+        test(`treats ${extension} files as eligible`, () => {
+            assert.equal(isEligibleAssetPath(`Assets/Thing${extension}`), true);
+        });
+
+        test(`treats uppercase ${extension.toUpperCase()} files as eligible`, () => {
+            assert.equal(isEligibleAssetPath(`Assets/Thing${extension.toUpperCase()}`), true);
+        });
+    }
+
+    for (const extension of ['.cs', '.png', '.fbx', '.json', '']) {
+        test(`treats ${extension || '(no extension)'} files as ineligible`, () => {
+            assert.equal(isEligibleAssetPath(`Assets/Thing${extension}`), false);
+        });
+    }
+});
+
+describe('containsNulByte', () => {
+    test('detects a NUL byte', () => {
+        assert.equal(containsNulByte(Buffer.from([0x61, 0x00, 0x62])), true);
+    });
+
+    test('returns false for plain text', () => {
+        assert.equal(containsNulByte(Buffer.from('hello world', 'utf8')), false);
+    });
+});
+
+describe('parseNulDelimitedList', () => {
+    test('splits on NUL and drops empty trailing entries', () => {
+        assert.deepEqual(parseNulDelimitedList('a/b.unity\0c/d.meta\0'), ['a/b.unity', 'c/d.meta']);
+    });
+
+    test('returns an empty array for empty input', () => {
+        assert.deepEqual(parseNulDelimitedList(''), []);
+    });
+});
+
+function createTempGitRepo() {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'unity-yaml-normalizer-'));
+    execFileSync('git', ['init', '--quiet'], { cwd: repoRoot });
+    return repoRoot;
+}
+
+function runScript(repoRoot) {
+    return spawnSync(process.execPath, [scriptPath, '--staged'], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+    });
+}
+
+describe('integration: --staged normalization', () => {
+    let repoRoot;
+    let unityFilePath;
+
+    before(() => {
+        repoRoot = createTempGitRepo();
+        mkdirSync(join(repoRoot, 'unity', 'three-bosses', 'Assets', 'Scenes'), { recursive: true });
+        unityFilePath = join(repoRoot, 'unity', 'three-bosses', 'Assets', 'Scenes', 'Level1.unity');
+        writeFileSync(unityFilePath, '%YAML 1.1\n--- !u!1 &1\nGameObject:  \n  name: Test  \n');
+        execFileSync('git', ['add', '--', 'unity/three-bosses/Assets/Scenes/Level1.unity'], { cwd: repoRoot });
+    });
+
+    after(() => {
+        rmSync(repoRoot, { recursive: true, force: true });
+    });
+
+    test('first run normalizes trailing whitespace, restages, and stops for inspection', () => {
+        const result = runScript(repoRoot);
+
+        assert.notEqual(result.status, 0);
+        assert.match(result.stdout, /Level1\.unity/);
+
+        const content = readFileSync(unityFilePath, 'utf8');
+        assert.equal(content, '%YAML 1.1\n--- !u!1 &1\nGameObject:\n  name: Test\n');
+
+        const staged = execFileSync(
+            'git',
+            ['diff', '--cached', '--name-only', '--', 'unity/three-bosses'],
+            { cwd: repoRoot, encoding: 'utf8' },
+        );
+        assert.match(staged, /Level1\.unity/);
+
+        const unstaged = execFileSync(
+            'git',
+            ['diff', '--name-only', '--', 'unity/three-bosses'],
+            { cwd: repoRoot, encoding: 'utf8' },
+        );
+        assert.equal(unstaged.trim(), '');
+    });
+
+    test('second run succeeds because no further normalization is required', () => {
+        const result = runScript(repoRoot);
+        assert.equal(result.status, 0);
+    });
+
+    test('git diff --cached --check succeeds after normalization', () => {
+        const result = spawnSync('git', ['diff', '--cached', '--check'], {
+            cwd: repoRoot,
+            encoding: 'utf8',
+        });
+        assert.equal(result.status, 0);
+    });
+});
+
+describe('integration: partially staged Unity file is rejected', () => {
+    let repoRoot;
+    let unityFilePath;
+    let stagedContent;
+    let workingTreeContentBeforeRun;
+
+    before(() => {
+        repoRoot = createTempGitRepo();
+        mkdirSync(join(repoRoot, 'unity', 'three-bosses', 'Assets', 'Scenes'), { recursive: true });
+        unityFilePath = join(repoRoot, 'unity', 'three-bosses', 'Assets', 'Scenes', 'Level2.unity');
+
+        writeFileSync(unityFilePath, '%YAML 1.1\nGameObject:  \n  name: Original  \n');
+        execFileSync('git', ['add', '--', 'unity/three-bosses/Assets/Scenes/Level2.unity'], { cwd: repoRoot });
+
+        // Further, unstaged edits after staging create a partially staged file.
+        writeFileSync(unityFilePath, '%YAML 1.1\nGameObject:  \n  name: Original  \n  extra: field \n');
+
+        stagedContent = execFileSync(
+            'git',
+            ['show', ':unity/three-bosses/Assets/Scenes/Level2.unity'],
+            { cwd: repoRoot, encoding: 'utf8' },
+        );
+        workingTreeContentBeforeRun = readFileSync(unityFilePath, 'utf8');
+    });
+
+    after(() => {
+        rmSync(repoRoot, { recursive: true, force: true });
+    });
+
+    test('aborts without modifying or restaging anything', () => {
+        const result = runScript(repoRoot);
+
+        assert.notEqual(result.status, 0);
+        assert.match(result.stderr, /Level2\.unity/);
+
+        const stagedAfter = execFileSync(
+            'git',
+            ['show', ':unity/three-bosses/Assets/Scenes/Level2.unity'],
+            { cwd: repoRoot, encoding: 'utf8' },
+        );
+        assert.equal(stagedAfter, stagedContent);
+
+        const workingTreeAfter = readFileSync(unityFilePath, 'utf8');
+        assert.equal(workingTreeAfter, workingTreeContentBeforeRun);
+    });
+});


### PR DESCRIPTION
﻿## What changed

- restore the `front`, `docs`, and `general` startup terminals with Git Bash, distinct icons, and colors
- start GitHub Copilot CLI automatically in the general terminal
- run documentation watch/serve without rebuilding merely because VS Code opened
- add an explicit `docs:dev:fresh` command for a full initial regeneration
- add root-workspace Unity extension, solution, and YAML configuration
- retain the nested Unity workspace for Attach to Unity debugging
- add a tracked pre-commit hook that safely normalizes staged Unity YAML trailing whitespace
- reject partially staged Unity assets rather than staging unrelated working-tree content

## Validation

- startup terminals tested across VS Code reloads
- frontend terminal starts in `frontend`
- docs watcher starts without dirtying tracked documentation
- Copilot CLI starts successfully from Git Bash
- root Unity editing configuration validated
- nested Unity Attach to Unity workflow validated
- Unity YAML normalizer: 33 tests passed
- package-lock, generated docs, and Unity assets remain unchanged